### PR TITLE
feat: add canonical and breadcrumb metadata

### DIFF
--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -1,0 +1,13 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "Home", "item": "{{ .Site.BaseURL }}"}
+    {{- if not .IsHome -}},
+    {"@type": "ListItem", "position": 2, "name": "Blog", "item": "{{ printf "%s%s/" .Site.BaseURL .Lang }}"},
+    {"@type": "ListItem", "position": 3, "name": "{{ .Title }}", "item": "{{ .Permalink }}"}
+    {{- end -}}
+  ]
+}
+</script>

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -6,6 +6,15 @@
 <meta name="msapplication-TileColor" content="#da532c">
 <meta name="theme-color" content="#ffffff">
 
+{{- if or (eq (getenv "HUGO_ENV") "production") (eq .Site.Params.env "production") -}}
+<link rel="canonical" href="{{ .Permalink }}">
+<meta name="robots" content="index, follow">
+{{- else -}}
+<meta name="robots" content="noindex, nofollow">
+{{- end -}}
+
+{{- partial "breadcrumbs.html" . -}}
+
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{ .Permalink }}">


### PR DESCRIPTION
## Summary
- add canonical and robots meta tags based on environment
- embed structured breadcrumb data for richer search snippets

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_689f00ca38cc833191bd07c9141571a4